### PR TITLE
Loading different attributes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ maintainers = [
 ]
 name = "LineageTree"
 description = "Structure for Lineage Trees"
-version = "2.2.0"
+version = "2.0.2"
 license = "MIT"
 license-files = [ "LICENSE" ]
 readme = {file = "README.md", content-type = "text/markdown"}
@@ -76,7 +76,7 @@ profile = "black"
 line_length = 79
 
 [tool.bumpver]
-current_version = "2.2.0"
+current_version = "2.0.2"
 version_pattern = "MAJOR.MINOR.PATCH[-TAG]"
 commit_message = "bump version {old_version} -> {new_version}"
 commit = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ maintainers = [
 ]
 name = "LineageTree"
 description = "Structure for Lineage Trees"
-version = "2.1.1"
+version = "2.0.1"
 license = "MIT"
 license-files = [ "LICENSE" ]
 readme = {file = "README.md", content-type = "text/markdown"}
@@ -76,7 +76,7 @@ profile = "black"
 line_length = 79
 
 [tool.bumpver]
-current_version = "2.1.1"
+current_version = "2.0.1"
 version_pattern = "MAJOR.MINOR.PATCH[-TAG]"
 commit_message = "bump version {old_version} -> {new_version}"
 commit = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ maintainers = [
 ]
 name = "LineageTree"
 description = "Structure for Lineage Trees"
-version = "2.0.1"
+version = "2.1.1"
 license = "MIT"
 license-files = [ "LICENSE" ]
 readme = {file = "README.md", content-type = "text/markdown"}
@@ -76,7 +76,7 @@ profile = "black"
 line_length = 79
 
 [tool.bumpver]
-current_version = "2.0.1"
+current_version = "2.1.1"
 version_pattern = "MAJOR.MINOR.PATCH[-TAG]"
 commit_message = "bump version {old_version} -> {new_version}"
 commit = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ maintainers = [
 ]
 name = "LineageTree"
 description = "Structure for Lineage Trees"
-version = "2.0.1"
+version = "2.2.0"
 license = "MIT"
 license-files = [ "LICENSE" ]
 readme = {file = "README.md", content-type = "text/markdown"}
@@ -76,7 +76,7 @@ profile = "black"
 line_length = 79
 
 [tool.bumpver]
-current_version = "2.0.1"
+current_version = "2.2.0"
 version_pattern = "MAJOR.MINOR.PATCH[-TAG]"
 commit_message = "bump version {old_version} -> {new_version}"
 commit = true

--- a/src/LineageTree/__init__.py
+++ b/src/LineageTree/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "2.2.0"
+__version__ = "2.0.2"
 from .lineageTree import lineageTree
 from .lineageTreeManager import lineageTreeManager
 from .loaders import (

--- a/src/LineageTree/__init__.py
+++ b/src/LineageTree/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "2.0.1"
+__version__ = "2.2.0"
 from .lineageTree import lineageTree
 from .lineageTreeManager import lineageTreeManager
 from .loaders import (

--- a/src/LineageTree/__init__.py
+++ b/src/LineageTree/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "2.0.1"
+__version__ = "2.1.1"
 from .lineageTree import lineageTree
 from .lineageTreeManager import lineageTreeManager
 from .loaders import (

--- a/src/LineageTree/__init__.py
+++ b/src/LineageTree/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "2.1.1"
+__version__ = "2.0.1"
 from .lineageTree import lineageTree
 from .lineageTreeManager import lineageTreeManager
 from .loaders import (

--- a/src/LineageTree/lineageTree.py
+++ b/src/LineageTree/lineageTree.py
@@ -1001,7 +1001,7 @@ class lineageTree:
             properties = {
                 prop_name: prop
                 for prop_name, prop in lT.__dict__.items()
-                if isinstance(prop, dict)
+                if (isinstance(prop, dict) or prop_name == "_time_resolution")
                 and prop_name
                 not in [
                     "successor",

--- a/src/LineageTree/lineageTree.py
+++ b/src/LineageTree/lineageTree.py
@@ -306,7 +306,6 @@ class lineageTree:
                     "predecessor",
                     "_successor",
                     "_predecessor",
-                    "_time",
                 ]:
                     attr_value.pop(node, ())
             if self._predecessor.get(node):


### PR DESCRIPTION
We only allow dict properties to be loaded. Some properties that are not dict should not be loaded, while others are important like the time resolution. Should we change the loader or add each important non dict attribute manually?