### PR TITLE
Solved incorrect nodes positions and figure size in tree graph

### DIFF
--- a/src/lineagetree/_core/utils.py
+++ b/src/lineagetree/_core/utils.py
@@ -97,7 +97,7 @@ def _find_leaves_and_depths_iterative(lnks_tms: dict, root: int) -> tuple[list[i
          
         if not succ:  # This is a leaf
             leaves.append(parent_node)
-        else: #TODO solve problem of children at same depth as parent
+        else:
             if len(succ) == 1: # in this case, times[parent_node] is equal to the length of the chain
                 child_depth = parent_depth + times[parent_node] - 1
             else: # in this case, times[parent_node] is 0

--- a/src/lineagetree/_core/utils.py
+++ b/src/lineagetree/_core/utils.py
@@ -79,7 +79,7 @@ def _find_leaves_and_depths_iterative(lnks_tms: dict, root: int) -> tuple[list[i
     leaves : list of int
         List of leaf node ids.
     depths : dict mapping int to int
-        Dictionary mapping node ids to their depth in the tree.
+        Dictionary mapping all node ids to their depth in the tree.
     """
     leaves = []
     depths = {}
@@ -88,19 +88,18 @@ def _find_leaves_and_depths_iterative(lnks_tms: dict, root: int) -> tuple[list[i
     stack = [(root, 0)]
     
     while stack:
-        node, parent_depth = stack.pop()
+        parent_node, parent_depth = stack.pop()
+        depths[parent_node] = parent_depth
          
-        node_depth = parent_depth + lnks_tms["times"].get(node, 0)
-        depths[node] = parent_depth
+        child_depth = parent_depth + lnks_tms["times"].get(parent_node, 0)
         
-        succ = lnks_tms["links"].get(node, [])
-        
+        succ = lnks_tms["links"].get(parent_node, [])
         if not succ:  # This is a leaf
-            leaves.append(node)
+            leaves.append(parent_node)
         else:
             # Add children to stack (reverse order to maintain left-to-right traversal)
             for child in reversed(succ):
-                stack.append((child, node_depth))
+                stack.append((child, child_depth))
     
     return leaves, depths
 

--- a/src/lineagetree/_core/utils.py
+++ b/src/lineagetree/_core/utils.py
@@ -96,7 +96,7 @@ def _find_leaves_and_depths_iterative(lnks_tms: dict, root: int) -> tuple[list[i
         succ = lnks_tms["links"].get(parent_node, [])
         if not succ:  # This is a leaf
             leaves.append(parent_node)
-        else:
+        else: #TODO solve problem of children at same depth as parent
             # Add children to stack (reverse order to maintain left-to-right traversal)
             for child in reversed(succ):
                 stack.append((child, child_depth))
@@ -157,7 +157,7 @@ def _assign_positions_iterative(
                 pos_node[succ[0]][0],
                 ycenter - depths[node] * vert_gap
             ]
-        else:
+        else:  #TODO solve problem of children at same depth as parent
             # Multiple children: place at center of children
             child_x_positions = [pos_node[child][0] for child in succ]
             center_x = sum(child_x_positions) / len(child_x_positions)

--- a/src/lineagetree/_core/utils.py
+++ b/src/lineagetree/_core/utils.py
@@ -162,7 +162,7 @@ def _assign_positions_iterative(
                 pos_node[succ[0]][0],
                 ycenter - depths[node] * vert_gap
             ]
-        else:  #TODO solve problem of children at same depth as parent
+        else:
             # Multiple children: place at center of children
             child_x_positions = [pos_node[child][0] for child in succ]
             center_x = sum(child_x_positions) / len(child_x_positions)

--- a/src/lineagetree/_core/utils.py
+++ b/src/lineagetree/_core/utils.py
@@ -83,20 +83,25 @@ def _find_leaves_and_depths_iterative(lnks_tms: dict, root: int) -> tuple[list[i
     """
     leaves = []
     depths = {}
+
+    times = lnks_tms["times"]
+    links = lnks_tms["links"]
     
-    # Stack for DFS: (node, current_depth, parent_depth)
+    # Stack for DFS: (node, parent_depth)
     stack = [(root, 0)]
     
     while stack:
         parent_node, parent_depth = stack.pop()
         depths[parent_node] = parent_depth
+        succ = links.get(parent_node, [])
          
-        child_depth = parent_depth + lnks_tms["times"].get(parent_node, 0)
-        
-        succ = lnks_tms["links"].get(parent_node, [])
         if not succ:  # This is a leaf
             leaves.append(parent_node)
         else: #TODO solve problem of children at same depth as parent
+            if len(succ) == 1: # in this case, times[parent_node] is equal to the length of the chain
+                child_depth = parent_depth + times[parent_node] - 1
+            else: # in this case, times[parent_node] is 0
+                child_depth = parent_depth + 1
             # Add children to stack (reverse order to maintain left-to-right traversal)
             for child in reversed(succ):
                 stack.append((child, child_depth))

--- a/src/lineagetree/plot.py
+++ b/src/lineagetree/plot.py
@@ -232,7 +232,7 @@ def plot_all_lineages(
         For example if start_time is 10, then all trees that begin
         on tp 10 or before are calculated. Defaults to None, where
         it will plot all the roots that exist on `lT.t_b`.
-    nrows : int, default=2
+    nrows : int, default=1
         How many rows of plots should be printed.
     figsize : tuple, default=(10, 15)
         The size of the figure.
@@ -327,7 +327,7 @@ def plot_all_lineages(
             },
         )
     [figure.delaxes(ax) for ax in flat_axes if not ax.has_data()]
-    return flat_axes[0].get_figure(), flat_axes, ax2root
+    return flat_axes[0].get_figure(), axes, ax2root
 
 
 def plot_subtree(

--- a/src/lineagetree/plot.py
+++ b/src/lineagetree/plot.py
@@ -211,7 +211,7 @@ def plot_all_lineages(
     lT: LineageTree,
     nodes: list | None = None,
     last_time_point_to_consider: int | None = None,
-    nrows: int = 2,
+    nrows: int = 1,
     figsize: tuple[int, int] = (10, 15),
     dpi: int = 100,
     fontsize: int = 15,
@@ -290,7 +290,7 @@ def plot_all_lineages(
             raise Exception(
                 f"Not enough axes, they should be at least {len(graphs)}."
             )
-    flat_axes = axes.flatten()
+    flat_axes = axes.flatten() if hasattr(axes, "flatten") else [axes]
     ax2root = {}
     min_width, min_height = float("inf"), float("inf")
     for ax in flat_axes:
@@ -326,8 +326,8 @@ def plot_all_lineages(
                 "edgecolor": "green",
             },
         )
-    [figure.delaxes(ax) for ax in axes.flatten() if not ax.has_data()]
-    return axes.flatten()[0].get_figure(), axes, ax2root
+    [figure.delaxes(ax) for ax in flat_axes if not ax.has_data()]
+    return flat_axes[0].get_figure(), flat_axes, ax2root
 
 
 def plot_subtree(


### PR DESCRIPTION
This PR solves 2 problems:
 - In `plot_all_lineages`, the figure grid is initialized with 2 lines by default, even if a single lineage is present. In that case, this leads to a figure with an incompressible white space below the lineage graph.
 - The lineage graphs assigned incorrect depths (vertical positions) to the nodes. Mother and daughters nodes are at the same depth, and some leaf nodes are not reachable in the GUI even when the napari time slider is put to its maximum value.

Both problems can be seen using the following code:
```python
from lineagetree import LineageTree
succs = {
    0: [1],
    1: [2],
    2: [3, 4],
    3: [5],
    5: [6],
    6: [],
    4: [7, 8],
    7: [9],
    9: [10],
    10: [],
    8: [11],
    11: [],
}
lt = LineageTree(successor=succs)
import matplotlib.pyplot as plt
lt.plot_all_lineages()
plt.show()
```
Results can be seen here:
<img height="1096" alt="pr_tree2" src="https://github.com/user-attachments/assets/1bfd7aac-5ee5-4a9f-92ee-6f163be061f2" />

