### PR TITLE
Adding standardized way to define loaders per extension 

### DIFF
--- a/src/lineagetree/__init__.py
+++ b/src/lineagetree/__init__.py
@@ -12,6 +12,7 @@ from ._io._loaders import (
     read_from_txt_for_celegans,
     read_from_txt_for_celegans_BAO,
     read_from_txt_for_celegans_CAO,
+    LOADERS,
 )
 from .lineage_tree_manager import LineageTreeManager
 
@@ -29,4 +30,5 @@ __all__ = (
     "read_from_mastodon",
     "read_from_txt_for_celegans",
     "read_from_txt_for_celegans_CAO",
+    "LOADERS",
 )

--- a/src/lineagetree/_io/_loaders.py
+++ b/src/lineagetree/_io/_loaders.py
@@ -1057,3 +1057,18 @@ def read_from_mamut_xml(
         name=name,
         **properties,
     )
+
+
+LOADERS = {
+    "bmf": {"BMF loader": read_from_bmf},
+    "csv": {"Standard CSV loader": read_from_csv, "Mastodon CSV loader": read_from_mastodon_csv},
+    "binary": {"Binary loader": read_from_binary},
+    "xml": {"TGMM XML loader": read_from_tgmm_xml, "MaMuT XML loader": read_from_mamut_xml, "ASTEC XML loader": read_from_ASTEC},
+    "mastodon": {"Mastodon loader": read_from_mastodon},
+    "pkl": {"ASTEC PKL loader": read_from_ASTEC},
+    "txt": {
+        "C. elegans loader": read_from_txt_for_celegans,
+        "C. elegans CAO loader": read_from_txt_for_celegans_CAO,
+        "C. elegans BAO loader": read_from_txt_for_celegans_BAO,
+    },
+}

--- a/src/lineagetree/_io/_loaders.py
+++ b/src/lineagetree/_io/_loaders.py
@@ -1060,16 +1060,27 @@ def read_from_mamut_xml(
 
 
 LOADERS = { # put all formats in smaller case
-    "bmf": {"BMF loader": read_from_bmf},
-    "csv": {"Standard CSV loader": read_from_csv, "Mastodon CSV loader": read_from_mastodon_csv},
-    "binary": {"Binary loader": read_from_binary},
+    "bmf": {
+        "BMF loader": read_from_bmf
+    },
+    "csv": {
+        "Standard CSV loader": read_from_csv,
+        "Mastodon CSV loader": read_from_mastodon_csv
+    },
+    "binary": {
+        "Binary loader": read_from_binary
+    },
     "xml": {
         # "TGMM XML loader": read_from_tgmm_xml, # commented out because it requires a specific file format
         "MaMuT XML loader": read_from_mamut_xml,
         "ASTEC XML loader": read_from_ASTEC,
     },
-    "mastodon": {"Mastodon loader": read_from_mastodon},
-    "pkl": {"ASTEC PKL loader": read_from_ASTEC},
+    "mastodon": {
+        "Mastodon loader": read_from_mastodon
+    },
+    "pkl": {
+        "ASTEC PKL loader": read_from_ASTEC
+    },
     "txt": {
         "C. elegans loader": read_from_txt_for_celegans,
         "C. elegans CAO loader": read_from_txt_for_celegans_CAO,

--- a/src/lineagetree/_io/_loaders.py
+++ b/src/lineagetree/_io/_loaders.py
@@ -177,7 +177,7 @@ def read_from_bmf(
 
 def read_from_csv(
     file_path: str,
-    z_mult: float,
+    z_mult: float = 1,
     link: int = 1,
     delim: str = ",",
     name: None | str = None,
@@ -1063,7 +1063,11 @@ LOADERS = {
     "bmf": {"BMF loader": read_from_bmf},
     "csv": {"Standard CSV loader": read_from_csv, "Mastodon CSV loader": read_from_mastodon_csv},
     "binary": {"Binary loader": read_from_binary},
-    "xml": {"TGMM XML loader": read_from_tgmm_xml, "MaMuT XML loader": read_from_mamut_xml, "ASTEC XML loader": read_from_ASTEC},
+    "xml": {
+        # "TGMM XML loader": read_from_tgmm_xml, # commented out because it requires a specific file format
+        "MaMuT XML loader": read_from_mamut_xml,
+        "ASTEC XML loader": read_from_ASTEC,
+    },
     "mastodon": {"Mastodon loader": read_from_mastodon},
     "pkl": {"ASTEC PKL loader": read_from_ASTEC},
     "txt": {

--- a/src/lineagetree/_io/_loaders.py
+++ b/src/lineagetree/_io/_loaders.py
@@ -1059,7 +1059,7 @@ def read_from_mamut_xml(
     )
 
 
-LOADERS = {
+LOADERS = { # put all formats in smaller case
     "bmf": {"BMF loader": read_from_bmf},
     "csv": {"Standard CSV loader": read_from_csv, "Mastodon CSV loader": read_from_mastodon_csv},
     "binary": {"Binary loader": read_from_binary},


### PR DESCRIPTION
This PR mostly adds a `LOADERS` dictionary in `_loader.py` to standardize the association of lineage file extension with loader function. This is meant to be used in relax to automatically choose whether a dialog window needs to open when the user loads an "ambiguous" extension (i.e several loader functions associated to this extension, e.g xml). 