### PR TITLE
Solving bug in mesh attribute access and default behavior when loading meshes 

### DIFF
--- a/src/lineagetree/_io/_loaders.py
+++ b/src/lineagetree/_io/_loaders.py
@@ -115,7 +115,7 @@ def _load_meshdict_from_bmfmesh(bmfmesh, pos_multipliers, translation):
 
 def read_from_bmf(
     file_path: str,
-    store_meshes: bool = False,
+    store_meshes: bool = True,
     pos_multipliers: tuple[float, float, float] = (1.0, 1.0, 1.0),
     translation: tuple[float, float, float] = (0.0, 0.0, 0.0),
     name: None | str = None,

--- a/src/lineagetree/_io/_loaders.py
+++ b/src/lineagetree/_io/_loaders.py
@@ -108,7 +108,8 @@ def _load_meshdict_from_bmfmesh(bmfmesh, pos_multipliers, translation):
 
     return { # could be a class
         'vertices': vertices,
-        'faces': faces
+        'faces': faces,
+        'center_mass': np.mean(vertices, axis=0),
     }
 
 
@@ -150,7 +151,7 @@ def read_from_bmf(
         pred = None
         for t, mesh in track.meshes.items():
             mesh = _load_meshdict_from_bmfmesh(mesh, pos_multipliers, translation)
-            pos[cell_id] = mesh.center_mass
+            pos[cell_id] = mesh["center_mass"]
             
             if store_meshes:
                 lT_mesh[cell_id] = mesh


### PR DESCRIPTION
Small PR to solve a bug that slipped my checks before the last merge.