### PR TITLE
do not add pos for root if none specified for add_root

### DIFF
--- a/src/lineagetree/_core/_modifier.py
+++ b/src/lineagetree/_core/_modifier.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from collections.abc import Callable, Iterable
 from functools import wraps
 from typing import TYPE_CHECKING
+import numpy as np
 
 if TYPE_CHECKING:
     from ..lineage_tree import LineageTree
@@ -97,7 +98,7 @@ def add_root(lT: LineageTree, t: int, pos: list | None = None) -> int:
     lT._predecessor[C_next] = ()
     lT._time[C_next] = t
     if isinstance(pos, (list, tuple)):
-        lT.pos[C_next] = list(pos)
+        lT.pos[C_next] = np.array(pos)
     lT._changed_roots = True
     return C_next
 

--- a/src/lineagetree/_core/_modifier.py
+++ b/src/lineagetree/_core/_modifier.py
@@ -96,7 +96,8 @@ def add_root(lT: LineageTree, t: int, pos: list | None = None) -> int:
     lT._successor[C_next] = ()
     lT._predecessor[C_next] = ()
     lT._time[C_next] = t
-    lT.pos[C_next] = pos if isinstance(pos, list) else []
+    if isinstance(pos, (list, tuple)):
+        lT.pos[C_next] = list(pos)
     lT._changed_roots = True
     return C_next
 


### PR DESCRIPTION
fixed bug that adds pos of root as an empty list while there should be nothing